### PR TITLE
Gravar null no BD quando property tipo date;datetime;time = 0

### DIFF
--- a/SimpleAttributes.pas
+++ b/SimpleAttributes.pas
@@ -44,7 +44,7 @@ type
   private
     FField: String;
     procedure SetField(const Value: String);
-  published
+  public
     constructor Create (aField : String);
     property Field : String read FField write SetField;
   end;

--- a/SimpleDAO.pas
+++ b/SimpleDAO.pas
@@ -329,6 +329,7 @@ begin
         end;
     finally
         FreeAndNil(DictionaryFields);
+        FreeAndNil(DictionaryTypeFields);
     end;
 end;
 

--- a/SimpleInterface.pas
+++ b/SimpleInterface.pas
@@ -63,6 +63,7 @@ type
     function TableName(var aTableName: String): ISimpleRTTI<T>;
     function ClassName (var aClassName : String) : iSimpleRTTI<T>;
     function DictionaryFields(var aDictionary : TDictionary<string, variant>) : iSimpleRTTI<T>;
+    function DictionaryTypeFields(var aDictionary: TDictionary<string, TFieldType>): iSimpleRTTI<T>;
     function ListFields (var List : TList<String>) : iSimpleRTTI<T>;
     function Update (var aUpdate : String) : iSimpleRTTI<T>;
     function Where (var aWhere : String) : iSimpleRTTI<T>;

--- a/SimpleRTTI.pas
+++ b/SimpleRTTI.pas
@@ -2,7 +2,7 @@
 {$MINSTACKSIZE $00004000}
 {$MAXSTACKSIZE $00100000}
 {$IMAGEBASE $00400000}
-{$APPTYPE GUI}
+
 {$WARN SYMBOL_DEPRECATED ON}
 {$WARN SYMBOL_LIBRARY ON}
 {$WARN SYMBOL_PLATFORM ON}
@@ -104,16 +104,15 @@ Type
   TSimpleRTTI<T : class, constructor> = class(TInterfacedObject, iSimpleRTTI<T>)
     private
       FInstance : T;
-      function __findRTTIField(ctxRtti : TRttiContext; classe: TClass; const Field: String): TRttiField;
+//      function __findRTTIField(ctxRtti : TRttiContext; classe: TClass; const Field: String): TRttiField;
       function __FloatFormat( aValue : String ) : Currency;
       {$IFNDEF CONSOLE}
       function __BindValueToComponent( aComponent : TComponent; aValue : Variant) : iSimpleRTTI<T>;
       function __GetComponentToValue( aComponent : TComponent) : TValue;
-      {$ENDIF}
       function __BindValueToProperty( aEntity : T; aProperty : TRttiProperty; aValue : TValue) : iSimpleRTTI<T>;
-
       function __GetRTTIPropertyValue(aEntity : T; aPropertyName : String) : Variant;
       function __GetRTTIProperty(aEntity : T; aPropertyName : String) : TRttiProperty;
+      {$ENDIF}
     public
       constructor Create( aInstance : T );
       destructor Destroy; override;
@@ -198,7 +197,7 @@ begin
 
 
 end;
-{$ENDIF}
+
 
 function TSimpleRTTI<T>.__BindValueToProperty( aEntity : T; aProperty : TRttiProperty; aValue : TValue) : iSimpleRTTI<T>;
 begin
@@ -235,15 +234,16 @@ begin
   end;
 
 end;
+{$ENDIF}
 
-function TSimpleRTTI<T>.__findRTTIField(ctxRtti: TRttiContext; classe: TClass;
-  const Field: String): TRttiField;
-var
-  typRtti : TRttiType;
-begin
-  typRtti := ctxRtti.GetType(classe.ClassInfo);
-  Result  := typRtti.GetField(Field);
-end;
+//function TSimpleRTTI<T>.__findRTTIField(ctxRtti: TRttiContext; classe: TClass;
+//  const Field: String): TRttiField;
+//var
+//  typRtti : TRttiType;
+//begin
+//  typRtti := ctxRtti.GetType(classe.ClassInfo);
+//  Result  := typRtti.GetField(Field);
+//end;
 
 function TSimpleRTTI<T>.__FloatFormat( aValue : String ) : Currency;
 begin
@@ -295,7 +295,6 @@ begin
 
   a := Result.TOString;
 end;
-{$ENDIF}
 
 function TSimpleRTTI<T>.__GetRTTIProperty(aEntity: T;
   aPropertyName: String): TRttiProperty;
@@ -324,7 +323,6 @@ begin
   Result := __GetRTTIProperty(aEntity, aPropertyName).GetValue(Pointer(aEntity)).AsVariant;
 end;
 
-{$IFNDEF CONSOLE}
 function TSimpleRTTI<T>.BindClassToForm(aForm: TForm;
   const aEntity: T): iSimpleRTTI<T>;
 var

--- a/SimpleValidator.pas
+++ b/SimpleValidator.pas
@@ -41,6 +41,9 @@ begin
 
   for prpRtti in typRttiEntity.GetProperties do
   begin
+    if prpRtti.IsIgnore then
+      Continue;
+
     Value := prpRtti.GetValue(aObject);
     if Value.IsObject then
       Validate(Value.AsObject, aErrors);


### PR DESCRIPTION
Ao gravar um objeto no SimpleORM que tenha a property do tipo TDateTime, TDate ou TTime, com valor 0 (zero), no banco de dados fica salvo o valor '30/12/1899'. Esse correção grava o valor "null" no BD quando colocar o 0 (zero) na property tipo Date.