### PR TITLE
BugFix - Persistencia Campos Enumerados e Persistencia FK com valor Null

### DIFF
--- a/SimpleAttributes.pas
+++ b/SimpleAttributes.pas
@@ -94,6 +94,14 @@ type
   BelongsToMany = class(Relationship)
   end;
 
+  Enumerator = class(TCustomAttribute)
+  private
+    FTipo: string;
+  public
+    Constructor Create(aTipo: string);
+    property Tipo: string read FTipo;
+  end;
+
 implementation
 
 
@@ -164,6 +172,13 @@ end;
 constructor Relationship.Create(const aEntityName: string);
 begin
   FEntityName := aEntityName;
+end;
+
+{ Enumerator }
+
+constructor Enumerator.Create(aTipo: string);
+begin
+  FTipo := aTipo;
 end;
 
 end.

--- a/SimpleRTTI.pas
+++ b/SimpleRTTI.pas
@@ -608,6 +608,9 @@ begin
       case prpRtti.PropertyType.TypeKind of
         tkInteger, tkInt64:
           begin
+            if prpRtti.EhChaveEstrangeira then
+              if prpRtti.GetValue(Pointer(FInstance)).AsInteger = 0 then
+                aDictionary.Add(prpRtti.FieldName, TFieldType.ftInteger);
           end;
         tkFloat       :
         begin

--- a/SimpleRTTI.pas
+++ b/SimpleRTTI.pas
@@ -608,9 +608,6 @@ begin
       case prpRtti.PropertyType.TypeKind of
         tkInteger, tkInt64:
           begin
-            if prpRtti.EhChaveEstrangeira then
-              if prpRtti.GetValue(Pointer(FInstance)).AsInteger = 0 then
-                aDictionary.Add(prpRtti.FieldName, TFieldType.ftInteger);
           end;
         tkFloat       :
         begin
@@ -734,6 +731,12 @@ begin
       if prpRtti.IsAutoInc then
         Continue;
 
+      if prpRtti.IsEnum then
+      begin
+        aParam := aParam + ':' + prpRtti.FieldName + '::' + prpRtti.EnumName + ', ';
+        Continue;
+      end;
+
       aParam  := aParam + ':' + prpRtti.FieldName + ', ';
     end;
   finally
@@ -803,6 +806,12 @@ begin
       if prpRtti.IsAutoInc then
         Continue;
 
+      if prpRtti.IsEnum then
+      begin
+        aUpdate := aUpdate + prpRtti.FieldName + ' = :' + prpRtti.FieldName + '::' + prpRtti.EnumName + ', ';
+        Continue;
+      end;
+
       aUpdate := aUpdate + prpRtti.FieldName + ' = :' + prpRtti.FieldName + ', ';
     end;
   finally
@@ -826,7 +835,10 @@ begin
     for prpRtti in typRtti.GetProperties do
     begin
       if prpRtti.EhChavePrimaria then
-        aWhere := aWhere + prpRtti.FieldName + ' = :' + prpRtti.FieldName + ' AND ';
+        if (prpRtti.IsEnum) then
+          aWhere := aWhere + prpRtti.FieldName + ' = :' + prpRtti.FieldName + '::' + prpRtti.EnumName + ' AND '
+        else
+          aWhere := aWhere + prpRtti.FieldName + ' = :' + prpRtti.FieldName + ' AND ';
     end;
   finally
     aWhere := Copy(aWhere, 0, Length(aWhere) - 4) + ' ';

--- a/SimpleRTTIHelper.pas
+++ b/SimpleRTTIHelper.pas
@@ -14,6 +14,7 @@ type
     function GetAttribute<T: TCustomAttribute>: T;
     function IsNotNull: Boolean;
     function IsIgnore: Boolean;
+    function IsEnum: Boolean;
     function IsAutoInc: Boolean;
     function EhCampo: Boolean;
     function EhChavePrimaria: Boolean;
@@ -22,6 +23,7 @@ type
     function EhPermitidoNulo: Boolean;
     function DisplayName: string;
     function FieldName: string;
+    function EnumName: string;
   end;
 
   TRttiTypeHelper = class helper for TRttiType
@@ -97,6 +99,11 @@ begin
   Result := Tem<Ignore>
 end;
 
+function TRttiPropertyHelper.IsEnum: Boolean;
+begin
+  Result := Tem<Enumerator>
+end;
+
 function TRttiPropertyHelper.IsAutoInc: Boolean;
 begin
   Result := Tem<AutoInc>
@@ -119,6 +126,12 @@ begin
     Result := GetAttribute<Campo>.Name;
 end;
 
+function TRttiPropertyHelper.EnumName: string;
+begin
+  Result := Name;
+  if IsEnum then
+    Result := GetAttribute<Enumerator>.Tipo;
+end;
 function TRttiPropertyHelper.Tem<T>: Boolean;
 begin
   Result := GetAttribute<T> <> nil


### PR DESCRIPTION
Erro Simulado: Ao tentar inserir ou atualizar em campos que são do tipo enumerado em banco de dados Postgres apresenta erro.
Driver: FireDac
Banco: PostgreSQL
Criado novo atributo customizado para informar qual o nome do enumerado correspondende ao banco de dados.
===========================================================================

Erro Simulado: Ao tentar inserir o valor Null para uma FK ocorria erro ao preparar a query.
Driver: FireDac
Banco: PostgreSQL

Foi observado que o DateType do parameter estava ficando como ftUnknown. Corrigido para quando o campo do RTTI for uma FK e seu valor for igual a zero atribuir ftInteger.